### PR TITLE
demonstrate development runtime backtracking

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  name: 'Alex'
+});

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,1 +1,3 @@
-{{x-button name="Alex"}}
+name={{name}}
+
+{{x-button name=name}}


### PR DESCRIPTION
This demonstrates a dev build runtime backtracking error. We're rendering the passed in `name` property before rendering the component. The component mutates this which causes the backtracking error:

<img width="1440" alt="screen shot 2018-12-07 at 09 18 17" src="https://user-images.githubusercontent.com/2526/49638805-3a9bcb00-fa01-11e8-8df4-f429e07ed8f2.png">
